### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ As a piece of software in its Alpha cycle, the code is continuously changing and
 1) Get Drupal: ``dktl get <drupal-version>``
 1) Get Drupal dependencies, and install DKAN: ``dktl make``
 1) Install DKAN: ``dktl install``
-1) Access the site: ``dktl drush uli --uri=dkan.local``
+1) Access the site: ``dktl uli``
 
 ## Dummy Content
 


### PR DESCRIPTION
On my linux dev machine, the dkan.local address always got an nginx 503 from the reverse proxy.

Obtaining the address via the dktl uli command worked.